### PR TITLE
feat(cli,ui): add flags and dry-run plan rendering; integrate plan builder

### DIFF
--- a/cmd/git-sweep/main.go
+++ b/cmd/git-sweep/main.go
@@ -4,8 +4,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"time"
+
+	gitpkg "github.com/jmelosegui/git-sweep/internal/git"
+	sweeppkg "github.com/jmelosegui/git-sweep/internal/sweep"
+	uipkg "github.com/jmelosegui/git-sweep/internal/ui"
 )
 
 var (
@@ -13,14 +19,42 @@ var (
 )
 
 func main() {
-	// Minimal flag set for now to ensure CLI wiring works
+	// Flags
 	showVersion := flag.Bool("version", false, "print version and exit")
+	remote := flag.String("remote", "origin", "git remote to use for fetch --prune")
+	include := flag.String("include", "", "regex to include branch names")
+	exclude := flag.String("exclude", "", "regex to exclude branch names")
+	jsonOut := flag.Bool("json", false, "print plan as JSON")
+	noColor := flag.Bool("no-color", true, "no-op placeholder: color not yet implemented")
+	yes := flag.Bool("yes", false, "auto-confirm deletions (not used yet; always dry-run)")
+	debug := flag.Bool("debug", false, "enable debug output (not used yet)")
 	flag.Parse()
+
+	_ = noColor
+	_ = yes
+	_ = debug
 
 	if *showVersion {
 		fmt.Println(version)
 		return
 	}
 
-	fmt.Println("git-sweep", version)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	r := gitpkg.ExecRunner{}
+	plan, err := sweeppkg.BuildPlan(ctx, r, sweeppkg.Options{
+		Remote:          *remote,
+		IncludePattern:  *include,
+		ExcludePattern:  *exclude,
+		ExtraProtected:  nil,
+		ProtectCurrent:  true,
+		ProtectUpstream: true,
+	})
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	_ = uipkg.PrintPlan(plan, uipkg.Options{JSON: *jsonOut})
 }

--- a/internal/ui/print.go
+++ b/internal/ui/print.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/jmelosegui/git-sweep/internal/sweep"
+)
+
+// Options controls how UI prints information.
+type Options struct {
+	JSON bool
+}
+
+// PrintPlan prints a sweep.Plan either as JSON or a human-readable summary.
+func PrintPlan(plan sweep.Plan, opts Options) error {
+	if opts.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(plan)
+	}
+	w := os.Stdout
+	if _, err := fmt.Fprintf(w, "Repository: %s\n", plan.RepoRoot); err != nil {
+		return err
+	}
+	if plan.Remote != "" {
+		if _, err := fmt.Fprintf(w, "Remote: %s\n", plan.Remote); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "Current: %s (upstream: %s)\n\n", plan.CurrentBranch, plan.CurrentUpstream); err != nil {
+		return err
+	}
+
+	if len(plan.Candidates) == 0 {
+		if _, err := fmt.Fprintln(w, "No local branches with gone upstreams found."); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintln(w, "Branches to delete (gone upstream):"); err != nil {
+		return err
+	}
+	for _, b := range plan.Candidates {
+		if _, err := fmt.Fprintf(w, "  - %s\n", b.Name); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "\nTotal: %d\n", len(plan.Candidates)); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
  - add flags: --remote, --include, --exclude, --json (+ placeholders: --yes, --no-color, --debug)
  - integrate sweep.BuildPlan: fetch --prune → discovery (for-each-ref, -vv fallback) → protections (default+env) → include/exclude filtering
  - render plan in human-readable and JSON formats
  - ensure fmt write errors are handled to satisfy lint rules