### PR TITLE
ci(lint): update .golangci.yml to v2.1 schema compatibility

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,7 @@
-version: 2
+version: "2"
+
 run:
   timeout: 3m
-  tests: true
-  skip-dirs:
-    - vendor
-    - bin
-    - dist
-    - build
-    - out
-    - tools
 
 linters:
   enable:
@@ -20,25 +13,3 @@ linters:
     - revive
     - gocritic
     - misspell
-
-linters-settings:
-  revive:
-    rules:
-      - name: exported
-        severity: warning
-        arguments:
-          - disableStutteringCheck
-      - name: blank-imports
-      - name: dot-imports
-      - name: var-naming
-      - name: if-return
-      - name: time-naming
-  misspell:
-    locale: US
-
-issues:
-  exclude-use-default: false
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude:
-    - "^Error return value of .*(Close|Stop|Quit|Flush).* is not checked$"


### PR DESCRIPTION
  - set version: 2 (string)
  - remove deprecated keys (skip-dirs, issues.exclude-use-default, linters-settings)
  - keep minimal enabled linter set compatible with action v8 (golangci-lint 2.1.x)