### PR TITLE
feat(cli,ui): git-like plan output and interactive confirmation

### DIFF
--- a/cmd/git-sweep/main.go
+++ b/cmd/git-sweep/main.go
@@ -73,16 +73,29 @@ func main() {
 		return
 	}
 
-	if err := uipkg.PrintPlan(plan, uipkg.Options{JSON: jsonOut}); err != nil {
+	count, err := uipkg.PrintPlan(plan, uipkg.Options{JSON: jsonOut})
+	if err != nil {
 		fmt.Println("error:", err)
 		return
 	}
 
-	if !yes {
+	if count == 0 {
 		return
 	}
 
-	// Execute deletions when --yes is provided; treat as consent to force-delete (-D)
+	// Interactive confirm if not --yes
+	if !yes {
+		ok, err := uipkg.ConfirmDeletion(count)
+		if err != nil {
+			fmt.Println("error:", err)
+			return
+		}
+		if !ok {
+			return
+		}
+	}
+
+	// Execute deletions; --yes or confirmed implies force-delete (-D)
 	res, err := sweeppkg.ExecuteDeletions(ctx, r, plan, sweeppkg.ExecuteOptions{MaxParallel: 0, ForceDelete: true})
 	if err != nil {
 		fmt.Println("error:", err)

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ConfirmDeletion prompts the user to confirm deletion of n branches.
+// Returns true when the user types "y" or "yes" (case-insensitive).
+// If stdin is not a terminal, it returns false with nil error.
+func ConfirmDeletion(n int) (bool, error) {
+	// Detect non-interactive stdin
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return false, err
+	}
+	if (info.Mode() & os.ModeCharDevice) == 0 {
+		return false, nil
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	if _, err := fmt.Fprintf(os.Stdout, "Proceed with deleting %d branch(es)? [y/N]: ", n); err != nil {
+		return false, err
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	ans := strings.TrimSpace(strings.ToLower(line))
+	return ans == "y" || ans == "yes", nil
+}


### PR DESCRIPTION
  - print plan in git-status style (branch/upstream, gone branches list, count)
  - prompt for confirmation when candidates exist; proceed if user answers yes
  - keep --yes to auto-confirm (non-interactive), deletions use -D on consent