### PR TITLE
fix(cli): friendlier error when run outside a git repository

### DIFF
--- a/cmd/git-sweep/main.go
+++ b/cmd/git-sweep/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -62,6 +63,10 @@ func main() {
 		ProtectUpstream: true,
 	})
 	if err != nil {
+		if errors.Is(err, gitpkg.ErrNotGitRepository) {
+			fmt.Println(err)
+			return
+		}
 		fmt.Println("error:", err)
 		return
 	}

--- a/internal/git/helpers.go
+++ b/internal/git/helpers.go
@@ -2,9 +2,16 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrNotGitRepository is returned when a git command fails because the
+// working directory is not inside a git repository. The error message
+// mirrors Git's own "fatal: not a git repository" output so it can be
+// surfaced to users without further translation.
+var ErrNotGitRepository = errors.New("fatal: not a git repository (or any of the parent directories): .git")
 
 // Version returns the output of `git --version`.
 func Version(ctx context.Context, r Runner) (string, error) {
@@ -20,6 +27,9 @@ func Version(ctx context.Context, r Runner) (string, error) {
 func IsInsideWorkTree(ctx context.Context, r Runner) (bool, error) {
 	res, err := r.Run(ctx, "rev-parse", "--is-inside-work-tree")
 	if err != nil {
+		if strings.Contains(res.Stderr, "not a git repository") {
+			return false, ErrNotGitRepository
+		}
 		return false, err
 	}
 	s := strings.TrimSpace(strings.ToLower(res.Stdout))

--- a/internal/git/helpers_test.go
+++ b/internal/git/helpers_test.go
@@ -1,0 +1,57 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubRunner struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func (s stubRunner) Run(_ context.Context, _ ...string) (Result, error) {
+	return Result{Stdout: s.stdout, Stderr: s.stderr}, s.err
+}
+
+func TestIsInsideWorkTree_NotARepository(t *testing.T) {
+	r := stubRunner{
+		stderr: "fatal: not a git repository (or any of the parent directories): .git",
+		err:    errors.New("git rev-parse --is-inside-work-tree: exit code 128: exit status 128"),
+	}
+	inside, err := IsInsideWorkTree(context.Background(), r)
+	if inside {
+		t.Fatalf("expected inside=false, got true")
+	}
+	if !errors.Is(err, ErrNotGitRepository) {
+		t.Fatalf("expected ErrNotGitRepository, got %v", err)
+	}
+}
+
+func TestIsInsideWorkTree_OtherFailurePassesThrough(t *testing.T) {
+	wantErr := errors.New("boom")
+	r := stubRunner{stderr: "permission denied", err: wantErr}
+	inside, err := IsInsideWorkTree(context.Background(), r)
+	if inside {
+		t.Fatalf("expected inside=false, got true")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected underlying error to propagate, got %v", err)
+	}
+	if errors.Is(err, ErrNotGitRepository) {
+		t.Fatalf("did not expect ErrNotGitRepository for unrelated failures")
+	}
+}
+
+func TestIsInsideWorkTree_True(t *testing.T) {
+	r := stubRunner{stdout: "true\n"}
+	inside, err := IsInsideWorkTree(context.Background(), r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !inside {
+		t.Fatalf("expected inside=true")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ErrNotGitRepository` sentinel in `internal/git` so callers can match the "not a git repository" failure with `errors.Is`.
- Translate the `rev-parse --is-inside-work-tree` failure in `IsInsideWorkTree` when stderr contains `not a git repository`.
- Print the sentinel verbatim from `main` so the CLI surfaces Git's own message instead of the internal exec output.
- Cover the new path in `helpers_test.go` (sentinel returned, unrelated failures pass through, success unchanged).

Before:
```
error: git rev-parse --is-inside-work-tree: exit code 128: exit status 128
```

After:
```
fatal: not a git repository (or any of the parent directories): .git
```

Closes #7.

## Test plan
- [ ] `go test ./...`
- [ ] `golangci-lint run ./...`
- [ ] Manual: from a non-repo directory, run `git-sweep` and confirm the new message
- [ ] Manual: from a real repo, run `git-sweep` and confirm normal plan output is unchanged