### PR TITLE
chore(issues): bump bug-report version placeholder to v0.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: git-sweep version
       description: Output of 'git sweep -V'.
-      placeholder: v0.0.1-rc.1
+      placeholder: v0.1.0
     validations:
       required: true
 


### PR DESCRIPTION
## Summary
- Updates the version-input placeholder in `.github/ISSUE_TEMPLATE/bug_report.yml` from `v0.0.1-rc.1` to `v0.1.0` ahead of the first proper release.
- Cosmetic only; no behavioral change.

## Test plan
- [ ] N/A (form metadata only)