### PR TITLE
ci(snap): pin Go channel via build-snaps and drop deprecated go-channel

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,8 +17,7 @@ parts:
   git-sweep:
     plugin: go
     source: .
-    build-snaps: [go]
-    go-channel: 1.24/stable
+    build-snaps: [go/1.24/stable]
     build-environment:
       - CGO_ENABLED: '0'
     override-build: |


### PR DESCRIPTION
## Summary

The snap workflow that fires on tag pushes failed during the v0.1.0 release with:

\`\`\`
has-base.core22.parts.git-sweep.go-channel
  Extra inputs are not permitted [type=extra_forbidden, input_value='1.24/stable', input_type=str]
\`\`\`

snapcraft 8.14 no longer accepts \`go-channel:\` as a field on \`core22\` parts. The modern way to pin the Go toolchain channel is on \`build-snaps\` itself using the \`snap[/track[/risk[/branch]]]\` form, so this swaps:

\`\`\`yaml
build-snaps: [go]
go-channel: 1.24/stable
\`\`\`

for:

\`\`\`yaml
build-snaps: [go/1.24/stable]
\`\`\`

The build environment, override-build, and version handling are unchanged.

This does not affect the v0.1.0 GitHub Release (already published with binaries the install scripts use). It only repairs the snap-store path so the next tag push won't fail the same way.

## Test plan
- [ ] Workflow runs cleanly on the next tag (no schema validation error during \`Install Snapcraft\`).
- [ ] Snap upload step succeeds when \`SNAPCRAFT_STORE_CREDENTIALS\` is configured.