### PR TITLE
ci: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,11 +21,11 @@ jobs:
     name: lint
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.x'
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: v2.7.0
           distribution: goreleaser

--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       SNAP_VERSION: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Snapcraft
         uses: snapcore/action-build@v1


### PR DESCRIPTION
## Summary

The v0.1.0 release run logged a Node.js 20 deprecation warning for every action that still ran on the older runtime. This bumps each affected action to the current major that ships with Node 24:

| Action | Old | New |
|---|---|---|
| \`actions/checkout\` | v4 | v6 |
| \`actions/setup-go\` | v5 | v6 |
| \`goreleaser/goreleaser-action\` | v6 | v7 |
| \`golangci/golangci-lint-action\` | v8 | v9 |

Reviewed each major's release notes -- the inputs we use (\`go-version\`, \`version\`, \`distribution\`, \`args\`) are unchanged. \`actions/setup-go@v6\` requires GitHub Actions runner >=2.327.1, which GitHub-hosted runners satisfy.

## Intentionally left untouched

- \`snapcore/action-build@v1\` -- upstream's \`action.yml\` on \`main\` still uses \`node20\`. No v2 published yet. Will revisit when upstream cuts a Node 24 release.
- \`vedantmgoyal2009/winget-releaser@v2\` -- composite action, no Node runtime, not affected by the deprecation.

## Test plan
- [x] CI workflow runs cleanly on this PR.
- [x] Lint workflow runs cleanly on this PR.
- [x] No \"Node.js 20 actions are deprecated\" annotation on any of the runs (other than from snapcore/action-build, which only fires on tag pushes).