### PR TITLE
feat(ui): print explicit abort message on non-yes confirmation input

### DIFF
--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -8,8 +8,10 @@ import (
 )
 
 // ConfirmDeletion prompts the user to confirm deletion of n branches.
-// Returns true when the user types "y" or "yes" (case-insensitive).
-// If stdin is not a terminal, it returns false with nil error.
+// Returns true when the user types "y" or "yes" (case-insensitive). Any
+// other answer prints "not a yes -- aborting." and returns false so the
+// user knows the input was treated as a decline rather than silently
+// dismissed. If stdin is not a terminal, it returns false with nil error.
 func ConfirmDeletion(n int) (bool, error) {
 	// Detect non-interactive stdin
 	info, err := os.Stdin.Stat()
@@ -28,6 +30,16 @@ func ConfirmDeletion(n int) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if interpretConfirm(line) {
+		return true, nil
+	}
+	if _, err := fmt.Fprintln(os.Stdout, "not a yes -- aborting."); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func interpretConfirm(line string) bool {
 	ans := strings.TrimSpace(strings.ToLower(line))
-	return ans == "y" || ans == "yes", nil
+	return ans == "y" || ans == "yes"
 }

--- a/internal/ui/confirm_test.go
+++ b/internal/ui/confirm_test.go
@@ -1,0 +1,27 @@
+package ui
+
+import "testing"
+
+func TestInterpretConfirm(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"yes\n", true},
+		{"YES\n", true},
+		{"  y  \n", true},
+		{"\n", false},
+		{"", false},
+		{"n\n", false},
+		{"no\n", false},
+		{"asdf\n", false},
+		{"yse\n", false},
+	}
+	for _, c := range cases {
+		if got := interpretConfirm(c.input); got != c.want {
+			t.Errorf("interpretConfirm(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Today the confirm prompt accepts \`y\` / \`yes\` (case-insensitive) and silently treats anything else -- including typos like \`yse\` or \`asdf\` -- as a decline. The user sees no acknowledgement; the program just exits without deleting.

This change keeps the safe-by-default semantics (anything that is not yes is still a decline) but prints \`not a yes -- aborting.\` whenever the input is not affirmative, so the user knows their input was understood:

\`\`\`
Proceed with deleting 1 branch(es)? [y/N]: asdf
not a yes -- aborting.
\`\`\`

The yes-detection logic is extracted into a small \`interpretConfirm\` helper so it can be unit-tested without faking stdin.

## Test plan
- [ ] \`go test ./...\` (new \`TestInterpretConfirm\` covers y/Y/yes/YES, leading/trailing space, empty Enter, EOF, n/no, typos).
- [ ] Manual: in a repo with deletable branches, run \`git-sweep\`, type \`asdf\` at the prompt; expect \`not a yes -- aborting.\` and no deletions.
- [ ] Manual: same flow with \`y\`; expect deletion to proceed.
- [ ] Manual: same flow with plain Enter; expect the abort message and no deletions.