### PR TITLE
docs(readme): add hero image at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # git-sweep
 
+![git-sweep](https://jmelosegui.com/img/projects/git-sweep.png)
+
 A small, cross-platform Go CLI that removes local branches whose upstream has been removed (e.g., branches marked as "[gone]"). Safe by default, dry-run first, and designed for Windows/macOS/Linux.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # git-sweep
 
-![git-sweep](https://jmelosegui.com/img/projects/git-sweep.png)
-
 A small, cross-platform Go CLI that removes local branches whose upstream has been removed (e.g., branches marked as "[gone]"). Safe by default, dry-run first, and designed for Windows/macOS/Linux.
+
+![git-sweep](https://jmelosegui.com/img/projects/git-sweep.png)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Inserts 
`![git-sweep](https://jmelosegui.com/img/projects/git-sweep.png)` 
directly under the `# git-sweep` heading.
- The image is referenced from \`jmelosegui.com\`. GitHub will proxy it through \`camo.githubusercontent.com\` automatically, so visitors do not hit the origin directly.

## Test plan
- [ ] Render preview on GitHub looks correct (image loads above the project tagline).