### PR TITLE
ci(snap): make snapcraft workflow iterable and add adopt-info

### DIFF
--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -4,12 +4,20 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    paths:
+      - 'snap/**'
+      - '.github/workflows/snapcraft.yml'
+  workflow_dispatch:
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
     env:
-      SNAP_VERSION: ${{ github.ref_name }}
+      # Use the tag as the snap version on tag pushes; otherwise use a dev
+      # placeholder so non-tag triggers (PRs, manual runs) still produce a
+      # valid version string.
+      SNAP_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '0.0.0-dev' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -20,7 +28,10 @@ jobs:
         run: snapcraft
 
       - name: Upload to Snap Store
-        if: success()
+        # Only publish on tag pushes. PRs and manual dispatch builds stop
+        # at the build step so we can iterate on snap/snapcraft.yaml
+        # without touching the store.
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: snapcraft upload *.snap --release=edge

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: git-sweep
 base: core22
+adopt-info: git-sweep
 summary: Remove local branches whose remote has been deleted (gone)
 description: |
   git-sweep is a small, cross-platform CLI that removes local branches whose upstream has been removed.


### PR DESCRIPTION
## Summary

Makes the snap workflow runnable on any branch and clears the next schema validation error so v0.1.1's snap build path can finally make it past validation.

### Workflow triggers
- Add \`workflow_dispatch\` so we can run the snap workflow on demand.
- Add \`pull_request\` filtered to \`snap/**\` and the workflow file itself, so future PRs that touch the snap config get automatic feedback.
- Tag-push trigger remains; \`snapcraft upload\` is now gated on \`refs/tags/v*\` so PR and dispatch builds stop at \`Build snap\` and never touch the snap store.
- \`SNAP_VERSION\` falls back to \`0.0.0-dev\` outside tag pushes so the version string is always valid.

### \`snap/snapcraft.yaml\`: add \`adopt-info: git-sweep\`
The v0.1.1 release run failed validation with:

\`\`\`
has-base.core22
  Value error, Required field 'version' is not set and 'adopt-info' not used.
\`\`\`

Snapcraft now requires an explicit \`adopt-info\` reference whenever the version is set inside an \`override-build\` step via \`craftctl set version=...\`. Pointing it at the existing \`git-sweep\` part satisfies the validator without changing how the version is computed.

## Test plan
- [ ] The \`snapcraft\` job on this PR runs (because \`snap/**\` and the workflow file are touched) and reaches at least the \`Build snap\` step without a schema error.
- [ ] After merge, \`gh workflow run snapcraft.yml --ref main\` runs cleanly.
- [ ] On the next \`vX.Y.Z\` tag push, the \`Upload to Snap Store\` step fires (gated on \`refs/tags/v*\`).